### PR TITLE
Pulling in some upstream changes to make sure we resolve project-relativ...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,11 +46,11 @@ module.exports = function(_arg) {
   var exclusion, extension, extensionsList, handleDirectory, parseDeps, prefix, regexp, rootPath, shallow, supportsGlob, _ref;
   _ref = _arg != null ? _arg : {}, rootPath = _ref.rootPath, extension = _ref.extension, regexp = _ref.regexp, prefix = _ref.prefix, exclusion = _ref.exclusion, extensionsList = _ref.extensionsList, supportsGlob = _ref.supportsGlob, handleDirectory = _ref.handleDirectory, shallow = _ref.shallow;
   parseDeps = function(data, path, depsList, callback) {
-    var altExts, deps, directoryFiles, extFiles, globs, parent, prefixed;
+    var altExts, deps, directoryFiles, dirs, extFiles, globs, parent, paths, prefixed;
     if (path) {
       parent = sysPath.dirname(path);
     }
-    deps = data.toString().split('\n').map(function(line) {
+    paths = data.toString().split('\n').map(function(line) {
       return line.match(regexp);
     }).filter(function(match) {
       return (match != null ? match.length : void 0) > 0;
@@ -70,12 +70,19 @@ module.exports = function(_arg) {
             return false;
         }
       });
-    }).map(function(path) {
-      if (path[0] === '/' || !parent) {
-        return sysPath.join(rootPath, path.slice(1));
-      } else {
-        return sysPath.join(parent, path);
-      }
+    });
+    dirs = [];
+    if (parent) {
+      dirs.push(parent);
+    }
+    if (rootPath && rootPath !== parent) {
+      dirs.push(rootPath);
+    }
+    deps = [];
+    dirs.forEach(function(dir) {
+      return paths.forEach(function(path) {
+        return deps.push(sysPath.join(dir, path));
+      });
     });
     if (supportsGlob) {
       globs = [];

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -28,7 +28,7 @@ module.exports =
 ({rootPath, extension, regexp, prefix, exclusion, extensionsList, supportsGlob, handleDirectory, shallow}={}) ->
   parseDeps = (data, path, depsList, callback) ->
     parent = sysPath.dirname path if path
-    deps = data
+    paths = data
       .toString()
       .split('\n')
       .map (line) ->
@@ -45,11 +45,15 @@ module.exports =
           when '[object String]' is toString.call _exclusion
             _exclusion is path
           else false
-      .map (path) ->
-        if path[0] is '/' or not parent
-          sysPath.join rootPath, path[1..]
-        else
-          sysPath.join parent, path
+
+    dirs = []
+    dirs.push parent if parent
+    dirs.push rootPath if rootPath and rootPath isnt parent
+
+    deps = []
+    dirs.forEach (dir) ->
+      paths.forEach (path) ->
+        deps.push sysPath.join dir, path
 
     if supportsGlob
       globs = []

--- a/test/fixtures/stylus/nested/stylus.styl
+++ b/test/fixtures/stylus/nested/stylus.styl
@@ -1,0 +1,2 @@
+
+@require 'testDir'

--- a/test/stylus.coffee
+++ b/test/stylus.coffee
@@ -57,4 +57,15 @@ describe 'Stylus', ->
         .to.not.include "#{@rootPath}/testDir/deep.styl"
       do done
 
+  it 'should find project-relative paths', (done) ->
+    progeny = progenyFunc
+      rootPath: @rootPath
+    fixtureFile = 'test/fixtures/stylus/nested/stylus.styl'
+    progeny null, fixtureFile, (err, dependencies) =>
+      chai.expect dependencies
+        .to.include.members [
+          "#{@rootPath}/testDir.styl"
+        ]
+      do done
+
 


### PR DESCRIPTION
...e paths properly.

@eleith PTAL.

The main issue (as you mentioned) was that project-relative paths weren't properly getting introduced as dependencies. This is because the previous iteration of this code made the (faulty) assumption that project-relative paths only ever existed with `/` prefixes, whereas we know in Stylus that they use a paths system to resolve dependencies.

This change allows dependencies to resolve both as a relative path as well as a project-relative path, and I've added a test to make sure this works as expected.

---

tl;dr: nested files would never resolve project-relative dependencies.

**NOTE: this has already been fixed upstream - we should reconcile ourselves with those updates and get our own changes upstream as well**
